### PR TITLE
feat/refactor to use async/await and update endpoint

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,11 +11,6 @@ TODO: add more information here about how to use / how it works
 If Twitch updates the scope permissions to hit an API follow these steps to update the skills
 
 ## TODO
-1. Update utils to use async/await
-1a. Update utils.test.js
-1b. Update index.js (handlers) to utilize async
-1c. Update all-the-tests.js if applicable
 1d. Better error handling for all functions
 1dd. If API call fails, need to handle err, or if invalid data returned
-2. Finish implementing the helix subscriber endpoint
 3. How to update the account linking and get users to reauth (forcibly) rather than, option, if they dont update they wont get the new subscriber endpoint

--- a/readme.md
+++ b/readme.md
@@ -3,3 +3,15 @@ Alexa skill that provides actions for streamers on Twitch.tv
 
 ## Deployments
 Run `npm run deploy` to run the script that uses the gulpfile to zip files and upload to the lambda function.
+
+TODO: add more information here about how to use / how it works
+
+
+## Updating Scoping Permissions
+If Twitch updates the scope permissions to hit an API follow these steps to update the skills
+
+TODO
+- How to update on the skill end
+- How to encourage/force users to reauth on login
+- Should be using async/await for utils instead of callbacks (need to get out of callback hell, will simplify by a lot)
+-- does it still work in the handlers tho?

--- a/readme.md
+++ b/readme.md
@@ -10,8 +10,10 @@ TODO: add more information here about how to use / how it works
 ## Updating Scoping Permissions
 If Twitch updates the scope permissions to hit an API follow these steps to update the skills
 
-TODO
-- How to update on the skill end
-- How to encourage/force users to reauth on login
-- Should be using async/await for utils instead of callbacks (need to get out of callback hell, will simplify by a lot)
--- does it still work in the handlers tho?
+## TODO
+1. Update utils to use async/await
+1a. Update utils.test.js
+1b. Update index.js (handlers) to utilize async
+1c. Update all-the-tests.js if applicable
+2. Finish implementing the helix subscriber endpoint
+3. How to update the account linking and get users to reauth (forcibly) rather than, option, if they dont update they wont get the new subscriber endpoint

--- a/readme.md
+++ b/readme.md
@@ -15,5 +15,7 @@ If Twitch updates the scope permissions to hit an API follow these steps to upda
 1a. Update utils.test.js
 1b. Update index.js (handlers) to utilize async
 1c. Update all-the-tests.js if applicable
+1d. Better error handling for all functions
+1dd. If API call fails, need to handle err, or if invalid data returned
 2. Finish implementing the helix subscriber endpoint
 3. How to update the account linking and get users to reauth (forcibly) rather than, option, if they dont update they wont get the new subscriber endpoint

--- a/src/index.js
+++ b/src/index.js
@@ -134,20 +134,20 @@ const handlers = {
             this.emit(':tellWithLinkAccountCard', responses.loginNeeded());
         }
     },
-    'createClip': function () {
+    'createClip': async function () {
         if(isAccessTokenValid(this.event.session.user.accessToken)) {
-            createClip(this.event.session.user.accessToken, (res) => {
-                if (res.clip === 'STREAM_OFFLINE') {
-                    this.emit(':tell', responses.clipStreamOffline());
-                }
-                else {
-                    var clipUrl = res.clip.edit_url;
-                    var clipUrlTrimmed = clipUrl.substring(0, clipUrl.length-5);
-                    sendTwitchMessage(clipUrlTrimmed, res.userName, (response) => {
-                        this.emit(':tellWithCard', responses.clipCreated(res.clip), 'Clip Created', 'Clip URL: ' + res.clip.edit_url);
-                    })
-                }   
-            });
+            const res = await createClip(this.event.session.user.accessToken);
+
+            if (res.clip === STREAM_OFFLINE) {
+                this.emit(':tell', responses.clipStreamOffline());
+            }
+            else {
+                var clipUrl = res.clip.edit_url;
+                var clipUrlTrimmed = clipUrl.substring(0, clipUrl.length-5);
+                sendTwitchMessage(clipUrlTrimmed, res.userName, () => {
+                    this.emit(':tellWithCard', responses.clipCreated(res.clip), 'Clip Created', 'Clip URL: ' + res.clip.edit_url);
+                })
+            }
         }
         else {
             this.emit(':tellWithLinkAccountCard', responses.loginNeeded());

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,6 @@ const responses = require('./responses');
 const {
     isAccessTokenValid,
     isStreamLive,
-    isStreamLiveAsync,
     getStreamUpTime,
     getFollowersCount,
     getFollowersLast,
@@ -35,7 +34,7 @@ const handlers = {
     },
     'isStreamLive': async function() {
         if(isAccessTokenValid(this.event.session.user.accessToken)) {
-            const isLive = await isStreamLiveAsync(this.event.session.user.accessToken);
+            const isLive = await isStreamLive(this.event.session.user.accessToken);
            
             isLive ?
                 this.emit(':tell', responses.streamLive()) :

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,8 @@ const {
     getSubscribersLast,
     getSubscribersLastFive,
     createClip,
-    sendTwitchMessage
+    sendTwitchMessage,
+    STREAM_OFFLINE
 } = require('./modules/utils');
 
 const {
@@ -44,13 +45,13 @@ const handlers = {
             this.emit(':tellWithLinkAccountCard', responses.loginNeeded());
         }
     },
-    'getStreamUpTime': function() {
+    'getStreamUpTime': async function() {
         if(isAccessTokenValid(this.event.session.user.accessToken)) {
-            getStreamUpTime(this.event.session.user.accessToken, (uptime) => {
-                uptime === 'STREAM_OFFLINE' ?
-                    this.emit(':tell', responses.streamNotLive()) :
-                    this.emit(':tellWithCard', responses.streamUpTime(uptime), 'Uptime', uptime.hours + 'hrs ' + uptime.minutes + 'mins');
-            });
+            const uptime = await getStreamUpTime(this.event.session.user.accessToken);
+
+            uptime === STREAM_OFFLINE ?
+                this.emit(':tell', responses.streamNotLive()) :
+                this.emit(':tellWithCard', responses.streamUpTime(uptime), 'Uptime', uptime.hours + 'hrs ' + uptime.minutes + 'mins');
         }
         else {
             this.emit(':tellWithLinkAccountCard', responses.loginNeeded());

--- a/src/index.js
+++ b/src/index.js
@@ -124,11 +124,11 @@ const handlers = {
             this.emit(':tellWithLinkAccountCard', responses.loginNeeded());
         }
     },
-    'getLastFiveSubscribers': function () {
+    'getLastFiveSubscribers': async function () {
         if(isAccessTokenValid(this.event.session.user.accessToken)) {
-            getSubscribersLastFive(this.event.session.user.accessToken, (subscribers) => {
-                this.emit(':tellWithCard', responses.lastXSubscribers(subscribers), 'Subscribers', 'Subscribers: ' + subscribers);
-            });
+            const subscribers = await getSubscribersLastFive(this.event.session.user.accessToken);
+
+            this.emit(':tellWithCard', responses.lastXSubscribers(subscribers), 'Subscribers', 'Subscribers: ' + subscribers);
         }
         else {
             this.emit(':tellWithLinkAccountCard', responses.loginNeeded());

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,8 @@ const {
     getSubscribersLastFive,
     createClip,
     sendTwitchMessage,
-    STREAM_OFFLINE
+    STREAM_OFFLINE,
+    NO_FOLLOWERS
 } = require('./modules/utils');
 
 const {
@@ -69,25 +70,25 @@ const handlers = {
             this.emit(':tellWithLinkAccountCard', responses.loginNeeded());
         }
     },
-    'getLastFollower': function () {
+    'getLastFollower': async function () {
         if(isAccessTokenValid(this.event.session.user.accessToken)) {
-            getFollowersLast(this.event.session.user.accessToken, (follower) => {
-                follower === 'NO_FOLLOWERS' ?
-                    this.emit(':tell', responses.noFollowers()) :
-                    this.emit(':tellWithCard', responses.lastFollower(follower), 'Followers', 'Last follower: ' + follower);
-            });
+            const follower = await getFollowersLast(this.event.session.user.accessToken);
+
+            follower === NO_FOLLOWERS ?
+                this.emit(':tell', responses.noFollowers()) :
+                this.emit(':tellWithCard', responses.lastFollower(follower), 'Followers', 'Last follower: ' + follower);
         }
         else {
             this.emit(':tellWithLinkAccountCard', responses.loginNeeded());
         }
     },
-    'getLastFiveFollowers': function () {
+    'getLastFiveFollowers': async function () {
         if(isAccessTokenValid(this.event.session.user.accessToken)) {
-            getFollowersLastFive(this.event.session.user.accessToken, (followers) => {
-                followers === 'NO_FOLLOWERS' ?
-                    this.emit(':tell', responses.noFollowers()) :
-                    this.emit(':tellWithCard', responses.lastXFollowers(followers), 'Followers', 'Followers: ' + followers);
-            });
+            const followers = await getFollowersLastFive(this.event.session.user.accessToken);
+            
+            followers === NO_FOLLOWERS ?
+                this.emit(':tell', responses.noFollowers()) :
+                this.emit(':tellWithCard', responses.lastXFollowers(followers), 'Followers', 'Followers: ' + followers);
         }
         else {
             this.emit(':tellWithLinkAccountCard', responses.loginNeeded());

--- a/src/index.js
+++ b/src/index.js
@@ -114,11 +114,11 @@ const handlers = {
             this.emit(':tellWithLinkAccountCard', responses.loginNeeded());
         }
     },
-    'getLastSubscriber': function () {
+    'getLastSubscriber': async function () {
         if(isAccessTokenValid(this.event.session.user.accessToken)) {
-            getSubscribersLast(this.event.session.user.accessToken, (subscriber) => {
-                this.emit(':tellWithCard', responses.lastSubscriber(subscriber), 'Subscribers', 'Last subscriber: ' + subscriber);
-            });
+            const subscriber = await getSubscribersLast(this.event.session.user.accessToken);
+
+            this.emit(':tellWithCard', responses.lastSubscriber(subscriber), 'Subscribers', 'Last subscriber: ' + subscriber);
         }
         else {
             this.emit(':tellWithLinkAccountCard', responses.loginNeeded());

--- a/src/index.js
+++ b/src/index.js
@@ -57,13 +57,13 @@ const handlers = {
             this.emit(':tellWithLinkAccountCard', responses.loginNeeded());
         }
     },
-    'getFollowerCount': function () {
+    'getFollowerCount': async function () {
         if(isAccessTokenValid(this.event.session.user.accessToken)) {
-            getFollowersCount(this.event.session.user.accessToken, (count) => {
-                count > 0 ?
-                    this.emit(':tellWithCard', responses.followerCount(count), 'Followers', 'Followers: ' + count) :
-                    this.emit(':tell', responses.noFollowers());
-            });
+            const count = await getFollowersCount(this.event.session.user.accessToken);
+
+            count > 0 ?
+                this.emit(':tellWithCard', responses.followerCount(count), 'Followers', 'Followers: ' + count) :
+                this.emit(':tell', responses.noFollowers());
         }
         else {
             this.emit(':tellWithLinkAccountCard', responses.loginNeeded());

--- a/src/index.js
+++ b/src/index.js
@@ -104,11 +104,11 @@ const handlers = {
             this.emit(':tellWithLinkAccountCard', responses.loginNeeded());
         }
     },
-    'getSubscriberCount': function () {
+    'getSubscriberCount': async function () {
         if(isAccessTokenValid(this.event.session.user.accessToken)) {
-            getSubscribersCount(this.event.session.user.accessToken, (count) => {
-                this.emit(':tellWithCard', responses.subscriberCount(count), 'Subscribers', 'Subscribers: ' + count);
-            });
+            const count = await getSubscribersCount(this.event.session.user.accessToken);
+
+            this.emit(':tellWithCard', responses.subscriberCount(count), 'Subscribers', 'Subscribers: ' + count);
         }
         else {
             this.emit(':tellWithLinkAccountCard', responses.loginNeeded());

--- a/src/index.js
+++ b/src/index.js
@@ -94,11 +94,11 @@ const handlers = {
             this.emit(':tellWithLinkAccountCard', responses.loginNeeded());
         }
     },
-    'getViewerCount': function () {
+    'getViewerCount': async function () {
         if(isAccessTokenValid(this.event.session.user.accessToken)) {
-            getViewerCount(this.event.session.user.accessToken, (count) => {
-                this.emit(':tellWithCard', responses.viewerCount(count), 'Viewers', 'Viewers: ' + count);
-            });
+            const count = await getViewerCount(this.event.session.user.accessToken);
+
+            this.emit(':tellWithCard', responses.viewerCount(count), 'Viewers', 'Viewers: ' + count);
         }
         else {
             this.emit(':tellWithLinkAccountCard', responses.loginNeeded());

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ const responses = require('./responses');
 const {
     isAccessTokenValid,
     isStreamLive,
+    isStreamLiveAsync,
     getStreamUpTime,
     getFollowersCount,
     getFollowersLast,
@@ -32,13 +33,13 @@ const handlers = {
     'LaunchRequest': function() {
         this.emit(':ask', responses.welcome(), responses.helpMessageReprompt());
     },
-    'isStreamLive': function() {
+    'isStreamLive': async function() {
         if(isAccessTokenValid(this.event.session.user.accessToken)) {
-            isStreamLive(this.event.session.user.accessToken, (isLive) => {
-                isLive ?
-                    this.emit(':tell', responses.streamLive()) :
-                    this.emit(':tell', responses.streamNotLive());
-            });
+            const isLive = await isStreamLiveAsync(this.event.session.user.accessToken);
+           
+            isLive ?
+                this.emit(':tell', responses.streamLive()) :
+                this.emit(':tell', responses.streamNotLive());
         }
         else {
             this.emit(':tellWithLinkAccountCard', responses.loginNeeded());

--- a/src/modules/utils.js
+++ b/src/modules/utils.js
@@ -230,7 +230,7 @@ function getSubscribers(accessToken, callback) {
 // TODO: wait to here back on forum about returning in order
 // Getsubscribersnew func will return first page (up to 100)
 
-async function getSubscribersNew(accessToken, pageCursor) {
+async function getSubscribersNew(accessToken, pageCursor = '') {
     const user = await getUserAsync(accessToken);
     const result = await newAsyncFetch({
         endpoint: 'subscribersNew',
@@ -243,17 +243,20 @@ async function getSubscribersNew(accessToken, pageCursor) {
     return result;
 }
 
-// function getSubscribersCountNew(accessToken, callback) {
-//     // TODO: Hit api multiple times w/ page # until data: [] 
-// }
+async function getSubscribersCount(accessToken) {
+    let shouldKeepPaging = true;
+    let count = 0;
+    let cursor = '';
 
-function getSubscribersCount(accessToken, callback) {
-    getSubscribers(accessToken, (subscribers) => {
-        const isPartnered = !!(subscribers._total);
-        const count = isPartnered ? subscribers._total : "NOT_A_PARTNER";
+    while(shouldKeepPaging) {
+        const pageResult = await getSubscribersNew(accessToken, cursor);
 
-        callback(count);
-    });
+        cursor = pageResult.pagination.cursor;
+        count = count + pageResult.data.length;
+        shouldKeepPaging = !!(pageResult.data.length);
+    }
+
+    return count;
 }
 
 // This won't be the TRUE last subscriber until Twitch update endpoint to make this possible (currently doesnt allow sorting)

--- a/src/modules/utils.js
+++ b/src/modules/utils.js
@@ -17,7 +17,7 @@ function getPath({path, userName, userId, accessToken, pageCursor}) {
         user: `/helix/users`,
         stream: `/helix/streams?user_id=${userId}`,
         followers: `/helix/users/follows?to_id=${userId}`,
-        subscribers: '/kraken/channels/' + userName + '/subscriptions?oauth_token=' + accessToken + "&direction=desc", //TODO: Update to helix once added to API
+        subscribers: '/kraken/channels/' + userName + '/subscriptions?oauth_token=' + accessToken + "&direction=desc", //TODO: Deprecate: Update to helix once added to API
         subscribersNew: `/helix/subscriptions?broadcaster_id=${userId}&first=100&after=${pageCursor}`, // TODO: Might need pass &user_id as well, &after={cursor} to get following pages
         createClip: `/helix/clips?broadcaster_id=${userId}`,
     };
@@ -227,18 +227,17 @@ function getSubscribers(accessToken, callback) {
 // TODO: wait to here back on forum about returning in order
 // Getsubscribersnew func will return first page (up to 100)
 
-function getSubscribersNew(accessToken, pageCursor, callback) {
-    getUser(accessToken, (user) => {
-        fetchJson({
-            endpoint: 'subscribersNew',
-            method: 'GET',
-            accessToken,
-            userId: user.userId,
-            pageCursor
-        }, (res) => {
-            callback(res);
-        });
+async function getSubscribersNew(accessToken, pageCursor) {
+    const user = await getUserAsync(accessToken);
+    const result = await newAsyncFetch({
+        endpoint: 'subscribersNew',
+        method: 'GET',
+        accessToken,
+        userId: user.userId,
+        pageCursor
     });
+
+    return result;
 }
 
 // function getSubscribersCountNew(accessToken, callback) {

--- a/src/modules/utils.js
+++ b/src/modules/utils.js
@@ -23,7 +23,7 @@ function getPath({path, userName, userId, accessToken, pageCursor}) {
     return paths[path];
 }
 
-// TODO: Try using just fetch instead (uses promises instead of callback)
+// TODO: Deprecate / remove
 function fetchJson({endpoint, method, accessToken, userName, userId, pageCursor}, callback) {
     var path = getPath({path: endpoint, userName, userId, accessToken, pageCursor});
 
@@ -59,8 +59,6 @@ function fetchJson({endpoint, method, accessToken, userName, userId, pageCursor}
     req.end();
 }
 
-// TODO: This should allow everything else to be converted to async/await and simplify it
-// TODO: Before refactor double check that the intents will work with async/await
 async function newAsyncFetch({endpoint, method, accessToken, userName, userId, pageCursor}) {
     const path = getPath({path: endpoint, userName, userId, accessToken, pageCursor});
     const options = {
@@ -98,20 +96,6 @@ async function getUserAsync(accessToken) {
     };
 }
 
-async function isStreamLiveAsync(accessToken) {
-    const user = await getUserAsync(accessToken);
-    const res = await newAsyncFetch({
-        endpoint: 'stream',
-        method: 'GET',
-        accessToken,
-        userId: user.userId
-    });
-
-    console.log('res', res);
-    const isLive = !!(res.data[0]);
-    return isLive;
-}
-
 function getUser(accessToken, callback) {
     fetchJson({
         endpoint: 'user',
@@ -125,18 +109,17 @@ function getUser(accessToken, callback) {
     });  
 }
 
-function isStreamLive(accessToken, callback) {
-    getUser(accessToken, (user) => {
-        fetchJson({
-            endpoint: 'stream',
-            method: 'GET',
-            accessToken,
-            userId: user.userId
-        }, (res) => {
-            const isLive = !!(res.data[0]);
-            callback(isLive);
-        });
+async function isStreamLive(accessToken) {
+    const user = await getUserAsync(accessToken);
+    const result = await newAsyncFetch({
+        endpoint: 'stream',
+        method: 'GET',
+        accessToken,
+        userId: user.userId
     });
+
+    const isLive = !!(result.data[0]);
+    return isLive;
 }
 
 function getStreamUpTime(accessToken, callback) {
@@ -344,7 +327,6 @@ function sendTwitchMessage(clipUrl, userName, callback) {
 
 module.exports = {
     isStreamLive: isStreamLive,
-    isStreamLiveAsync: isStreamLiveAsync,
     isAccessTokenValid: isAccessTokenValid,
     getUser: getUser,
     getFollowers: getFollowers,

--- a/src/modules/utils.js
+++ b/src/modules/utils.js
@@ -155,23 +155,22 @@ async function getStreamUpTime(accessToken) {
     }
 }
 
-function getFollowers(accessToken, callback) {
-    getUser(accessToken, (user) => {
-        fetchJson({
-            endpoint: 'followers',
-            method: 'GET',
-            accessToken,
-            userId: user.userId
-        }, (res) => {
-            callback(res);
-        });
+async function getFollowers(accessToken) {
+    const user = await getUserAsync(accessToken);
+    const result = await newAsyncFetch({
+        endpoint: 'followers',
+        method: 'GET',
+        accessToken,
+        userId: user.userId
     });
+
+    return result;
 }
 
-function getFollowersCount(accessToken, callback) {
-    getFollowers(accessToken, (followers) => {
-        callback(followers.total);
-    });
+async function getFollowersCount(accessToken) {
+    const followers = await getFollowers(accessToken);
+
+    return followers.total;
 }
 
 function getFollowersLast(accessToken, callback) {

--- a/src/modules/utils.js
+++ b/src/modules/utils.js
@@ -223,13 +223,7 @@ function getSubscribers(accessToken, callback) {
 }
 
 // TODO: Need to update the account linking and add more params
-// TODO: Verify what response looks like for zero subs - just returns empty array same shape
-// TODO: what response looks like for non partner/affiliate - just returns empty array same shape
-// TODO: getsubscribers count will need to use ?after=paginationCursor
-// TODO: getsubscribersLast should be able to use ?first=1 (to get last sub)
-// TODO: wait to here back on forum about returning in order
-// Getsubscribersnew func will return first page (up to 100)
-
+//Returns one page (up to 100) at a time
 async function getSubscribersNew(accessToken, pageCursor = '') {
     const user = await getUserAsync(accessToken);
     const result = await newAsyncFetch({
@@ -295,23 +289,19 @@ async function getSubscribersLastFive(accessToken) {
     return lastFiveSubscribers;
 }
 
-function createClip(accessToken, callback) {
-    getUser(accessToken, (user) => {
-        fetchJson({
-            endpoint: 'createClip',
-            method: 'POST',
-            accessToken,
-            userId: user.userId
-        }, (res) => {
-            const clip = res.data ? res.data[0] : "STREAM_OFFLINE";
-            const val = {
-                userName: user.userName,
-                clip
-            }
+async function createClip(accessToken) {
+    const user = await getUserAsync(accessToken);
+    const result = await newAsyncFetch({
+        endpoint: 'createClip',
+        method: 'POST',
+        accessToken,
+        userId: user.userId
+    });
 
-            callback(val);
-        });
-    })
+    return {
+        userName: user.userName,
+        clip: result.data ? result.data[0] : STREAM_OFFLINE
+    };
 }
 
 function sendTwitchMessage(clipUrl, userName, callback) {

--- a/src/modules/utils.js
+++ b/src/modules/utils.js
@@ -6,6 +6,7 @@ const {
     TwitchBotPassword
 } = require('../secrets/credentials');
 const STREAM_OFFLINE = 'STREAM_OFFLINE';
+const NO_FOLLOWERS = 'NO_FOLLOWERS';
 
 function isAccessTokenValid(accessToken) {
     return !!(accessToken);
@@ -173,21 +174,23 @@ async function getFollowersCount(accessToken) {
     return followers.total;
 }
 
-function getFollowersLast(accessToken, callback) {
-    getFollowers(accessToken, (followers) => {
-        const follower = followers.total === 0 ? 'NO_FOLLOWERS' : followers.data[0].from_name;
-        callback(follower);
-    });
+async function getFollowersLast(accessToken) {
+    const followers = await getFollowers(accessToken);
+
+    const follower = followers.total === 0 ? NO_FOLLOWERS : followers.data[0].from_name;
+    return follower;
 }
 
-function getFollowersLastFive(accessToken, callback) {
-    getFollowers(accessToken, (followers) => {
-        const lastFiveFollowers = followers.total === 0 ? 'NO_FOLLOWERS' : followers.data.slice(0, 5).map(followers => {
-            return followers.from_name;
+async function getFollowersLastFive(accessToken) {
+    const followers = await getFollowers(accessToken);
+
+    const lastFiveFollowers = followers.total === 0 ?
+        NO_FOLLOWERS : 
+        followers.data.slice(0, 5).map(follower => {
+            return follower.from_name;
         });
  
-        callback(lastFiveFollowers);
-    });
+    return lastFiveFollowers;
 }
 
 function getViewerCount(accessToken, callback) {
@@ -344,5 +347,6 @@ module.exports = {
     getStreamUpTime: getStreamUpTime,
     createClip: createClip,
     sendTwitchMessage: sendTwitchMessage,
-    STREAM_OFFLINE
+    STREAM_OFFLINE,
+    NO_FOLLOWERS
 };

--- a/src/modules/utils.js
+++ b/src/modules/utils.js
@@ -2,9 +2,9 @@ const https = require('https');
 const tmi = require('tmi.js');
 const fetch = require('node-fetch');
 
-// const {
-//     TwitchBotPassword
-// } = require('../secrets/credentials');
+const {
+    TwitchBotPassword
+} = require('../secrets/credentials');
 const STREAM_OFFLINE = 'STREAM_OFFLINE';
 const NO_FOLLOWERS = 'NO_FOLLOWERS';
 

--- a/src/modules/utils.js
+++ b/src/modules/utils.js
@@ -2,9 +2,9 @@ const https = require('https');
 const tmi = require('tmi.js');
 const fetch = require('node-fetch');
 
-const {
-    TwitchBotPassword
-} = require('../secrets/credentials');
+// const {
+//     TwitchBotPassword
+// } = require('../secrets/credentials');
 const STREAM_OFFLINE = 'STREAM_OFFLINE';
 const NO_FOLLOWERS = 'NO_FOLLOWERS';
 
@@ -193,18 +193,17 @@ async function getFollowersLastFive(accessToken) {
     return lastFiveFollowers;
 }
 
-function getViewerCount(accessToken, callback) {
-    getUser(accessToken, (user) => {
-        fetchJson({
-            endpoint: 'stream',
-            method: 'GET',
-            accessToken,
-            userId: user.userId
-        }, (res) => {
-            const count = res.data[0] ? res.data[0].viewer_count : 0;
-            callback(count);
-        });
+async function getViewerCount(accessToken) {
+    const user = await getUserAsync(accessToken);
+    const result = await newAsyncFetch({
+        endpoint: 'stream',
+        method: 'GET',
+        accessToken,
+        userId: user.userId
     });
+
+    const count = result.data[0] ? result.data[0].viewer_count : 0;
+    return count;
 }
 
 function getSubscribers(accessToken, callback) {

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -2910,6 +2910,11 @@
         "https-proxy-agent": "^1.0.0"
       }
     },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streamhelper",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "A Twitch tool to helper streamers",
   "main": "index.js",
   "scripts": {

--- a/src/package.json
+++ b/src/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha ./tests/*.tests.js",
-    "test-utils": "mocha ./modules/tests/*.tests.js",
+    "test-utils": "mocha ./tests/utils.tests.js",
     "lint": "eslint ./**/*.js",
     "postinstall": "npm i alexa-sdk tmi.js --prefix dist",
     "deploy": "gulp deploy",
@@ -30,7 +30,8 @@
   "homepage": "https://github.com/tyhilde/StreamHelper#readme",
   "dependencies": {
     "alexa-sdk": "^1.0.25",
-    "tmi.js": "^1.2.1"
+    "tmi.js": "^1.2.1",
+    "node-fetch": "2.6.0"
   },
   "devDependencies": {
     "aws-lambda-mock-context": "^3.0.0",

--- a/src/responses.js
+++ b/src/responses.js
@@ -78,10 +78,7 @@ module.exports.subscriberCount = (count) => {
 }
 
 module.exports.lastSubscriber = (subscriber) => {
-    if (subscriber === 'NOT_A_PARTNER') {
-        return 'You have zero subscribers, you are not a Twitch partner or affiliate.';
-    }
-    else if (subscriber === 'NO_SUBSCRIBERS') {
+    if (subscriber === 'NO_SUBSCRIBERS') {
         return 'You currently do not have any subscribers.';
     }
     else {

--- a/src/responses.js
+++ b/src/responses.js
@@ -64,16 +64,11 @@ module.exports.viewerCount = (count) => {
 }
 
 module.exports.subscriberCount = (count) => {
-    if (count === 'NOT_A_PARTNER') {
-        return 'You have zero subscribers, you are not a Twitch partner or affiliate.';
+    if(count === 1) {
+        return `You currently have one subscriber.`;
     }
     else {
-        if(count === 1) { // Counts self as a subscriber
-            return `You currently do not have any subscribers.`;
-        }
-        else {
-            return `You currently have ${count} subscribers.`;
-        }
+        return `You currently have ${count} subscribers.`;
     }
 }
 

--- a/src/responses.js
+++ b/src/responses.js
@@ -87,10 +87,7 @@ module.exports.lastSubscriber = (subscriber) => {
 }
 
 module.exports.lastXSubscribers = (subscribers) => {
-    if (subscribers === 'NOT_A_PARTNER') {
-        return 'You have zero subscribers, you are not a Twitch partner or affiliate.';
-    }
-    else if (subscribers === 'NO_SUBSCRIBERS') {
+    if (subscribers === 'NO_SUBSCRIBERS') {
         return 'You currently do not have any subscribers.';
     }
     else {

--- a/src/tests/utils-run-examples.js
+++ b/src/tests/utils-run-examples.js
@@ -7,14 +7,18 @@ const {ClientAccessToken} = require('../secrets/credentials');
 //     console.log('getuser res', res);
 // })
 
-(async function isStreamLive() {
+async function isStreamLive() {
     var res = await utils.isStreamLive(ClientAccessToken);
     console.log('isStreamLive res', res);
-})();
+};
 
-// utils.getStreamUpTime(ClientAccessToken, (res) => {
-//     console.log('getStreamupTime res', res);
-// })
+async function getStreamUpTime() {
+    var res = await utils.getStreamUpTime(ClientAccessToken);
+    console.log('getStreamUpTime res', res);
+};
+
+// isStreamLive();
+getStreamUpTime();
 
 // utils.getFollowers(ClientAccessToken, (res) => {
 //     console.log('getFollowers res', res);

--- a/src/tests/utils-run-examples.js
+++ b/src/tests/utils-run-examples.js
@@ -57,6 +57,11 @@ async function getSubscribersLastFive() {
     console.log('getSubscribersLastFive res', res);
 };
 
+async function getSubscribersCount() {
+    var res = await utils.getSubscribersCount(ClientAccessToken);
+    console.log('getSubscribersCount res', res);
+};
+
 // isStreamLive();
 // getStreamUpTime();
 // getFollowers();
@@ -66,23 +71,12 @@ async function getSubscribersLastFive() {
 // getViewerCount();
 // getSubscribersNew();
 // getSubscribersLast();
-getSubscribersLastFive();
+// getSubscribersLastFive();
+getSubscribersCount();
 
 // utils.getSubscribers(ClientAccessToken, (res) => {
 //     console.log('old getSubscribers res', res);
 //     console.log('old getSubscribers res', res.subscriptions);
-// })
-
-// utils.getSubscribersCountNew(ClientAccessToken, (res) => {
-//     console.log('new getSubscribersCountNew res', res);
-// })
-
-// utils.getSubscribersCount(ClientAccessToken, (res) => {
-//     console.log('getSubscribersCount res', res);
-// })
-
-// utils.getSubscribersLastFive(ClientAccessToken, (res) => {
-//     console.log('getSubscribersLastFive res', res);
 // })
 
 // utils.createClip(ClientAccessToken, (res) => {

--- a/src/tests/utils-run-examples.js
+++ b/src/tests/utils-run-examples.js
@@ -17,16 +17,20 @@ async function getStreamUpTime() {
     console.log('getStreamUpTime res', res);
 };
 
+async function getFollowers() {
+    var res = await utils.getFollowers(ClientAccessToken);
+    console.log('getFollowers res', res);
+};
+
+async function getFollowersCount() {
+    var res = await utils.getFollowersCount(ClientAccessToken);
+    console.log('getFollowersCount res', res);
+};
+
 // isStreamLive();
-getStreamUpTime();
-
-// utils.getFollowers(ClientAccessToken, (res) => {
-//     console.log('getFollowers res', res);
-// });
-
-// utils.getFollowersCount(ClientAccessToken, (res) => {
-//     console.log('followersCount res', res);
-// })
+// getStreamUpTime();
+// getFollowers();
+getFollowersCount();
 
 // utils.getFollowersLast(ClientAccessToken, (res) => {
 //     console.log('getFollowersLast res', res);

--- a/src/tests/utils-run-examples.js
+++ b/src/tests/utils-run-examples.js
@@ -37,12 +37,18 @@ async function getFollowersLastFive() {
     console.log('getFollowersLastFive res', res);
 };
 
+async function getViewerCount() {
+    var res = await utils.getViewerCount(ClientAccessToken);
+    console.log('getViewerCount res', res);
+};
+
 // isStreamLive();
 // getStreamUpTime();
 // getFollowers();
 // getFollowersCount();
 // getFollowersLast();
-getFollowersLastFive();
+// getFollowersLastFive();
+getViewerCount();
 
 // utils.getViewerCount(ClientAccessToken, (res) => {
 //     console.log('getViewerCount res', res);

--- a/src/tests/utils-run-examples.js
+++ b/src/tests/utils-run-examples.js
@@ -47,6 +47,11 @@ async function getSubscribersNew() {
     console.log('getSubscribersNew res', res);
 };
 
+async function getSubscribersLast() {
+    var res = await utils.getSubscribersLast(ClientAccessToken);
+    console.log('getSubscribersLast res', res);
+};
+
 // isStreamLive();
 // getStreamUpTime();
 // getFollowers();
@@ -54,16 +59,12 @@ async function getSubscribersNew() {
 // getFollowersLast();
 // getFollowersLastFive();
 // getViewerCount();
-getSubscribersNew();
+// getSubscribersNew();
+getSubscribersLast();
 
 // utils.getSubscribers(ClientAccessToken, (res) => {
 //     console.log('old getSubscribers res', res);
 //     console.log('old getSubscribers res', res.subscriptions);
-// })
-
-// utils.getSubscribersNew(ClientAccessToken, '', (res) => {
-//     console.log('new getSubscribers res', res);
-//     // console.log('new getSubscribers res', res.data);
 // })
 
 // utils.getSubscribersCountNew(ClientAccessToken, (res) => {
@@ -72,10 +73,6 @@ getSubscribersNew();
 
 // utils.getSubscribersCount(ClientAccessToken, (res) => {
 //     console.log('getSubscribersCount res', res);
-// })
-
-// utils.getSubscribersLast(ClientAccessToken, (res) => {
-//     console.log('getSubscribersLast res', res);
 // })
 
 // utils.getSubscribersLastFive(ClientAccessToken, (res) => {

--- a/src/tests/utils-run-examples.js
+++ b/src/tests/utils-run-examples.js
@@ -7,6 +7,15 @@ const {ClientAccessToken} = require('../secrets/credentials');
 //     console.log('getuser res', res);
 // })
 
+async function testFunc() {
+    // var res = await utils.getUser(ClientAccessToken);
+    // console.log('res', res);
+
+    var res = await utils.isStreamLiveAsync(ClientAccessToken);
+    console.log('streamLive res', res);
+};
+testFunc();
+
 // utils.isStreamLive(ClientAccessToken, (res) => {
 //     console.log('streamLive res', res);
 // })
@@ -36,8 +45,17 @@ const {ClientAccessToken} = require('../secrets/credentials');
 // })
 
 // utils.getSubscribers(ClientAccessToken, (res) => {
-//     console.log('getSubscribers res', res);
-//     console.log('getSubscribers res', res.subscriptions);
+//     console.log('old getSubscribers res', res);
+//     console.log('old getSubscribers res', res.subscriptions);
+// })
+
+// utils.getSubscribersNew(ClientAccessToken, '', (res) => {
+//     console.log('new getSubscribers res', res);
+//     // console.log('new getSubscribers res', res.data);
+// })
+
+// utils.getSubscribersCountNew(ClientAccessToken, (res) => {
+//     console.log('new getSubscribersCountNew res', res);
 // })
 
 // utils.getSubscribersCount(ClientAccessToken, (res) => {

--- a/src/tests/utils-run-examples.js
+++ b/src/tests/utils-run-examples.js
@@ -52,6 +52,11 @@ async function getSubscribersLast() {
     console.log('getSubscribersLast res', res);
 };
 
+async function getSubscribersLastFive() {
+    var res = await utils.getSubscribersLastFive(ClientAccessToken);
+    console.log('getSubscribersLastFive res', res);
+};
+
 // isStreamLive();
 // getStreamUpTime();
 // getFollowers();
@@ -60,7 +65,8 @@ async function getSubscribersLast() {
 // getFollowersLastFive();
 // getViewerCount();
 // getSubscribersNew();
-getSubscribersLast();
+// getSubscribersLast();
+getSubscribersLastFive();
 
 // utils.getSubscribers(ClientAccessToken, (res) => {
 //     console.log('old getSubscribers res', res);

--- a/src/tests/utils-run-examples.js
+++ b/src/tests/utils-run-examples.js
@@ -3,9 +3,10 @@
 var utils = require('../modules/utils');
 const {ClientAccessToken} = require('../secrets/credentials');
 
-// utils.getUser(ClientAccessToken, (res) => {
-//     console.log('getuser res', res);
-// })
+async function getUser() {
+    var res = await utils.getUser(ClientAccessToken);
+    console.log('getUser res', res);
+}
 
 async function isStreamLive() {
     var res = await utils.isStreamLive(ClientAccessToken);
@@ -42,9 +43,9 @@ async function getViewerCount() {
     console.log('getViewerCount res', res);
 };
 
-async function getSubscribersNew() {
-    var res = await utils.getSubscribersNew(ClientAccessToken, '');
-    console.log('getSubscribersNew res', res);
+async function getSubscribers() {
+    var res = await utils.getSubscribers(ClientAccessToken, '');
+    console.log('getSubscribers res', res);
 };
 
 async function getSubscribersLast() {
@@ -67,6 +68,7 @@ async function createClip() {
     console.log('createClip res', res);
 };
 
+// getUser();
 // isStreamLive();
 // getStreamUpTime();
 // getFollowers();
@@ -74,20 +76,11 @@ async function createClip() {
 // getFollowersLast();
 // getFollowersLastFive();
 // getViewerCount();
-// getSubscribersNew();
+// getSubscribers();
 // getSubscribersLast();
 // getSubscribersLastFive();
 // getSubscribersCount();
-createClip();
-
-// utils.getSubscribers(ClientAccessToken, (res) => {
-//     console.log('old getSubscribers res', res);
-//     console.log('old getSubscribers res', res.subscriptions);
-// })
-
-// utils.createClip(ClientAccessToken, (res) => {
-//     console.log('createClip res', res);
-// })
+// createClip();
 
 // utils.sendTwitchMessage('someMessage test', 'backsh00ter',  (res) => {
 //     console.log('sendTwitchMessage res', res);

--- a/src/tests/utils-run-examples.js
+++ b/src/tests/utils-run-examples.js
@@ -27,18 +27,22 @@ async function getFollowersCount() {
     console.log('getFollowersCount res', res);
 };
 
+async function getFollowersLast() {
+    var res = await utils.getFollowersLast(ClientAccessToken);
+    console.log('getFollowersLast res', res);
+};
+
+async function getFollowersLastFive() {
+    var res = await utils.getFollowersLastFive(ClientAccessToken);
+    console.log('getFollowersLastFive res', res);
+};
+
 // isStreamLive();
 // getStreamUpTime();
 // getFollowers();
-getFollowersCount();
-
-// utils.getFollowersLast(ClientAccessToken, (res) => {
-//     console.log('getFollowersLast res', res);
-// })
-
-// utils.getFollowersLastFive(ClientAccessToken, (res) => {
-//     console.log('getFollowersLastFive res', res);
-// })
+// getFollowersCount();
+// getFollowersLast();
+getFollowersLastFive();
 
 // utils.getViewerCount(ClientAccessToken, (res) => {
 //     console.log('getViewerCount res', res);

--- a/src/tests/utils-run-examples.js
+++ b/src/tests/utils-run-examples.js
@@ -42,17 +42,19 @@ async function getViewerCount() {
     console.log('getViewerCount res', res);
 };
 
+async function getSubscribersNew() {
+    var res = await utils.getSubscribersNew(ClientAccessToken, '');
+    console.log('getSubscribersNew res', res);
+};
+
 // isStreamLive();
 // getStreamUpTime();
 // getFollowers();
 // getFollowersCount();
 // getFollowersLast();
 // getFollowersLastFive();
-getViewerCount();
-
-// utils.getViewerCount(ClientAccessToken, (res) => {
-//     console.log('getViewerCount res', res);
-// })
+// getViewerCount();
+getSubscribersNew();
 
 // utils.getSubscribers(ClientAccessToken, (res) => {
 //     console.log('old getSubscribers res', res);

--- a/src/tests/utils-run-examples.js
+++ b/src/tests/utils-run-examples.js
@@ -7,18 +7,10 @@ const {ClientAccessToken} = require('../secrets/credentials');
 //     console.log('getuser res', res);
 // })
 
-async function testFunc() {
-    // var res = await utils.getUser(ClientAccessToken);
-    // console.log('res', res);
-
-    var res = await utils.isStreamLiveAsync(ClientAccessToken);
-    console.log('streamLive res', res);
-};
-testFunc();
-
-// utils.isStreamLive(ClientAccessToken, (res) => {
-//     console.log('streamLive res', res);
-// })
+(async function isStreamLive() {
+    var res = await utils.isStreamLive(ClientAccessToken);
+    console.log('isStreamLive res', res);
+})();
 
 // utils.getStreamUpTime(ClientAccessToken, (res) => {
 //     console.log('getStreamupTime res', res);

--- a/src/tests/utils-run-examples.js
+++ b/src/tests/utils-run-examples.js
@@ -62,6 +62,11 @@ async function getSubscribersCount() {
     console.log('getSubscribersCount res', res);
 };
 
+async function createClip() {
+    var res = await utils.createClip(ClientAccessToken);
+    console.log('createClip res', res);
+};
+
 // isStreamLive();
 // getStreamUpTime();
 // getFollowers();
@@ -72,7 +77,8 @@ async function getSubscribersCount() {
 // getSubscribersNew();
 // getSubscribersLast();
 // getSubscribersLastFive();
-getSubscribersCount();
+// getSubscribersCount();
+createClip();
 
 // utils.getSubscribers(ClientAccessToken, (res) => {
 //     console.log('old getSubscribers res', res);

--- a/src/tests/utils.tests.js
+++ b/src/tests/utils.tests.js
@@ -28,11 +28,11 @@ describe('isAccessTokenValid', () => {
 })
 
 describe('getUser', () => {
-    it('returns the userId', (done) => {
-        utils.getUser(accessToken, (res) => {
-            assert.deepEqual(res, {userId: userId, userName: userName});
-            done();
-        });
+    it('returns the userId', async (done) => {
+        const res = await utils.getUser(accessToken);
+
+        assert.deepEqual(res, {userId: userId, userName: userName});
+        done();
     });
 });
 
@@ -315,14 +315,14 @@ describe('subscribersNew', () => {
         }
     };
 
-    describe('getSubscribersNew', () => {
+    describe('getSubscribers', () => {
         it('returns object containing array of subscribers', async (done) => {
             nock('https://api.twitch.tv')
                 .get(`/helix/subscriptions?broadcaster_id=${userId}&first=100&after=`)
                 .reply(200, subscriberResponse);
 
 
-            const res = await utils.getSubscribersNew(accessToken, '');
+            const res = await utils.getSubscribers(accessToken, '');
 
             assert.deepEqual(res, subscriberResponse);
             done();
@@ -333,7 +333,7 @@ describe('subscribersNew', () => {
                 .get(`/helix/subscriptions?broadcaster_id=${userId}&first=100&after=`)
                 .reply(200, {data: [],  pagination: {cursor: 'cursor1'}});
 
-            const res = await utils.getSubscribersNew(accessToken, '');
+            const res = await utils.getSubscribers(accessToken, '');
 
             assert.deepEqual(res, {data: [],  pagination: {cursor: 'cursor1'}});
             done();

--- a/src/tests/utils.tests.js
+++ b/src/tests/utils.tests.js
@@ -61,34 +61,34 @@ describe('isStreamLive', () => {
 });
 
 describe('getStreamUpTime', () => {
-    it('returns STREAM_OFFLINE if stream isnt up', (done) => {
+    it('returns STREAM_OFFLINE if stream isnt up', async (done) => {
         nock('https://api.twitch.tv')
             .get(`/helix/streams?user_id=${userId}`)
             .reply(200, {data: []});
 
-        utils.getStreamUpTime(accessToken, (res) => {
-            assert.equal(res, 'STREAM_OFFLINE');
-            done();
-        });
+        const res = await utils.getStreamUpTime(accessToken);
+
+        assert.equal(res, utils.STREAM_OFFLINE);
+        done();
     });
 
-    it('returns the stream up time', (done) => {
+    it('returns the stream up time', async (done) => {
         nock('https://api.twitch.tv')
             .get(`/helix/streams?user_id=${userId}`)
             .reply(200, {data: [{started_at: "2018-12-13T05:30:00Z"}]});
 
-        utils.getStreamUpTime(accessToken, (res) => {
-            const startDate = new Date("2018-12-13T05:30:00Z");
-            const currentDate = new Date();
-            const totalMins = Math.floor((currentDate - startDate) / (1000 * 60));
-            const uptime = {
-                minutes: totalMins % 60,
-                hours: Math.floor(totalMins / 60)
-            };
+        const res = await utils.getStreamUpTime(accessToken);
 
-            assert.deepEqual(res, uptime);
-            done();
-        });
+        const startDate = new Date("2018-12-13T05:30:00Z");
+        const currentDate = new Date();
+        const totalMins = Math.floor((currentDate - startDate) / (1000 * 60));
+        const uptime = {
+            minutes: totalMins % 60,
+            hours: Math.floor(totalMins / 60)
+        };
+
+        assert.deepEqual(res, uptime);
+        done();
     });
 });
 

--- a/src/tests/utils.tests.js
+++ b/src/tests/utils.tests.js
@@ -205,8 +205,8 @@ describe('followers', () => {
 });
 
 describe('viewers', () => {
-    describe('getViewerCount', () => {
-        it('returns the count of viewers when stream is live', (done) => {
+    describe('getViewerCount', async () => {
+        it('returns the count of viewers when stream is live', async (done) => {
             const viewerResponse = {
                 data: [
                     {
@@ -215,29 +215,29 @@ describe('viewers', () => {
                 ]
             };
 
-            const viewersNock = nock('https://api.twitch.tv')
+            nock('https://api.twitch.tv')
                 .get(`/helix/streams?user_id=${userId}`)
                 .reply(200, viewerResponse);
 
-            utils.getViewerCount(accessToken, (res) => {
-                assert.equal(res, viewerResponse.data[0].viewer_count);
-                done();
-            });
+            const res = await utils.getViewerCount(accessToken);
+
+            assert.equal(res, viewerResponse.data[0].viewer_count);
+            done();
         });
 
-        it('returns 0 when there are no viewers', (done) => {
+        it('returns 0 when there are no viewers', async (done) => {
             const viewerResponse = {
                 data: []
             };
 
-            const viewersNock = nock('https://api.twitch.tv')
+            nock('https://api.twitch.tv')
                 .get(`/helix/streams?user_id=${userId}`)
                 .reply(200, viewerResponse);
 
-            utils.getViewerCount(accessToken, (res) => {
-                assert.deepEqual(res, 0);
-                done();
-            });
+            const res = await utils.getViewerCount(accessToken);
+
+            assert.deepEqual(res, 0);
+            done();
         });
     });
 });

--- a/src/tests/utils.tests.js
+++ b/src/tests/utils.tests.js
@@ -111,28 +111,28 @@ describe('followers', () => {
     };
     
     describe('getFollowers', () => {
-        it('returns object containing followers', (done) => {
-            const followersNock = nock('https://api.twitch.tv')
+        it('returns object containing followers', async (done) => {
+            nock('https://api.twitch.tv')
                 .get(`/helix/users/follows?to_id=${userId}`)
                 .reply(200, followerResponse);
 
-            utils.getFollowers(accessToken, (res) => {
-                assert.deepEqual(res, followerResponse);
-                done();
-            });
+            const res = await utils.getFollowers(accessToken);
+
+            assert.deepEqual(res, followerResponse);
+            done();
         });
     });
 
     describe('getFollowersCount', () => {
-        it('returns the count of followers', (done) => {
-            const followersNock = nock('https://api.twitch.tv')
+        it('returns the count of followers', async (done) => {
+            nock('https://api.twitch.tv')
                 .get(`/helix/users/follows?to_id=${userId}`)
                 .reply(200, followerResponse);
             
-            utils.getFollowersCount(accessToken, (res) => {
-                assert.equal(res, followerResponse.total);
-                done();
-            });
+            const res = await utils.getFollowersCount(accessToken);
+                
+            assert.equal(res, followerResponse.total);
+            done();
         });
     });
 

--- a/src/tests/utils.tests.js
+++ b/src/tests/utils.tests.js
@@ -436,8 +436,8 @@ describe('subscribersNew', () => {
                 user_name: 'userName1'
             },
             {
-                broadcaster_id: 'broadcasterId1',
-                broadcaster_name: 'broadcasterName1',
+                broadcaster_id: 'broadcasterId2',
+                broadcaster_name: 'broadcasterName2',
                 is_gift: false,
                 plan_name: 'Channel Subscription',
                 tier: '1000',
@@ -445,13 +445,13 @@ describe('subscribersNew', () => {
                 user_name: 'userName2'
             },
             { 
-                broadcaster_id: '32799121',
-                broadcaster_name: 'BackSH00TER',
+                broadcaster_id: 'broadcasterId3',
+                broadcaster_name: 'broadcasterName3',
                 is_gift: false,
-                plan_name: 'Channel Subscription (backsh00ter)',
+                plan_name: 'Channel Subscription',
                 tier: '1000',
-                user_id: '65406844',
-                user_name: 'Crusader_09'
+                user_id: 'userId3',
+                user_name: 'userName3'
             }
           ],
         pagination: {
@@ -459,26 +459,27 @@ describe('subscribersNew', () => {
         }
     };
 
-    it('returns object containing array of subscribers', (done) => {
-        const subscriberNock = nock('https://api.twitch.tv')
+    it('returns object containing array of subscribers', async (done) => {
+        nock('https://api.twitch.tv')
             .get(`/helix/subscriptions?broadcaster_id=${userId}&first=100&after=`)
             .reply(200, subscriberResponse);
 
-        utils.getSubscribersNew(accessToken, '', (res) => {
-            assert.deepEqual(res, subscriberResponse);
-            done();
-        });
+
+        const res = await utils.getSubscribersNew(accessToken, '');
+
+        assert.deepEqual(res, subscriberResponse);
+        done();
     });
 
-    it('returns correct object when empty array of subscribers', (done) => {
-        const subscriberNock = nock('https://api.twitch.tv')
+    it('returns correct object when empty array of subscribers', async (done) => {
+        nock('https://api.twitch.tv')
             .get(`/helix/subscriptions?broadcaster_id=${userId}&first=100&after=`)
             .reply(200, {data: [],  pagination: {cursor: 'cursor1'}});
 
-        utils.getSubscribersNew(accessToken, '', (res) => {
-            assert.deepEqual(res, {data: [],  pagination: {cursor: 'cursor1'}});
-            done();
-        });
+        const res = await utils.getSubscribersNew(accessToken, '');
+
+        assert.deepEqual(res, {data: [],  pagination: {cursor: 'cursor1'}});
+        done();
     });
 });
 

--- a/src/tests/utils.tests.js
+++ b/src/tests/utils.tests.js
@@ -137,42 +137,42 @@ describe('followers', () => {
     });
 
     describe('getFollowersLast', () => {
-        it('returns the last follower', (done) => {
-            const followersNock = nock('https://api.twitch.tv')
+        it('returns the last follower', async (done) => {
+            nock('https://api.twitch.tv')
                 .get(`/helix/users/follows?to_id=${userId}`)
                 .reply(200, followerResponse);
             
-            utils.getFollowersLast(accessToken, (res) => {
-                assert.equal(res, followerResponse.data[0].from_name);
-                done();
-            });
+            const res = await utils.getFollowersLast(accessToken);
+
+            assert.equal(res, followerResponse.data[0].from_name);
+            done();
         });
 
-        it('returns the NO_FOLLOWERS if there are none', (done) => {
-            const followersNock = nock('https://api.twitch.tv')
+        it('returns the NO_FOLLOWERS if there are none', async (done) => {
+            nock('https://api.twitch.tv')
                 .get(`/helix/users/follows?to_id=${userId}`)
                 .reply(200, noFollowersResponse);
             
-            utils.getFollowersLast(accessToken, (res) => {
-                assert.equal(res, 'NO_FOLLOWERS');
-                done();
-            });
+            const res = await utils.getFollowersLast(accessToken);
+
+            assert.equal(res, utils.NO_FOLLOWERS);
+            done();
         });
     });
 
     describe('getFollowersLastFive', () => {
-       it('returns an array of the last five followers', (done) => {
-            const followersNock = nock('https://api.twitch.tv')
+       it('returns an array of the last five followers', async (done) => {
+            nock('https://api.twitch.tv')
                 .get(`/helix/users/follows?to_id=${userId}`)
                 .reply(200, followerResponse);
         
-            utils.getFollowersLastFive(accessToken, (res) => {
-                assert.deepEqual(res, ['follower1', 'follower2', 'follower3', 'follower4', 'follower5']);
-                done();
-            });
+            const res = await utils.getFollowersLastFive(accessToken);
+
+            assert.deepEqual(res, ['follower1', 'follower2', 'follower3', 'follower4', 'follower5']);
+            done();
         });
 
-        it('returns an array of the last two followers if there are only 2', (done) => {
+        it('returns an array of the last two followers if there are only 2', async (done) => {
             const followerResponseTwo = {
                 total: 2,
                 data: [
@@ -185,21 +185,21 @@ describe('followers', () => {
                 .get(`/helix/users/follows?to_id=${userId}`)
                 .reply(200, followerResponseTwo);
 
-            utils.getFollowersLastFive(accessToken, (res) => {
-                assert.deepEqual(res, ['follower1', 'follower2']);
-                done();
-            });
+            const res = await utils.getFollowersLastFive(accessToken);
+
+            assert.deepEqual(res, ['follower1', 'follower2']);
+            done();
         });
 
-        it('returns the NO_FOLLOWERS if there are none', (done) => {
-            const followersNock = nock('https://api.twitch.tv')
+        it('returns the NO_FOLLOWERS if there are none', async (done) => {
+            nock('https://api.twitch.tv')
                 .get(`/helix/users/follows?to_id=${userId}`)
                 .reply(200, noFollowersResponse);
             
-            utils.getFollowersLastFive(accessToken, (res) => {
-                assert.equal(res, 'NO_FOLLOWERS');
-                done();
-            });
+            const res = await utils.getFollowersLastFive(accessToken);
+
+            assert.equal(res, utils.NO_FOLLOWERS);
+            done();
         });
     });
 });

--- a/src/tests/utils.tests.js
+++ b/src/tests/utils.tests.js
@@ -242,37 +242,6 @@ describe('viewers', () => {
     });
 });
 
-describe('subscribers', () => {
-    const subscriberResponse = {
-        _total: 2,
-        subscriptions: [
-            {
-                user: {
-                    display_name: 'user1'
-                }, 
-            },
-            {
-                user: {
-                    display_name: 'user2'
-                }, 
-            }
-        ]
-    };
-
-    describe('getSubscribers', () => {
-        it('returns object containing subscribers', (done) => {
-            const subscriberNock = nock('https://api.twitch.tv')
-                .get(`/kraken/channels/${userName}/subscriptions?oauth_token=${accessToken}&direction=desc`)
-                .reply(200, subscriberResponse);
-
-            utils.getSubscribers(accessToken, (res) => {
-                assert.deepEqual(res, subscriberResponse);
-                done();
-            });
-        });
-    });
-});
-
 describe('subscribersNew', () => {
     const subscriberResponse = {
         data: [ 
@@ -490,7 +459,7 @@ describe('subscribersNew', () => {
 });
 
 describe('createClip', () => {
-    it('returns the id and url of the created clip', (done) => {
+    it('returns the id and url of the created clip', async (done) => {
         const createClipResponse = {
             data: [
                 {
@@ -500,30 +469,30 @@ describe('createClip', () => {
             ]
          };
 
-         const createClipNock = nock('https://api.twitch.tv')
-             .post(`/helix/clips?broadcaster_id=${userId}`)
-             .reply(200, createClipResponse);
+        nock('https://api.twitch.tv')
+            .post(`/helix/clips?broadcaster_id=${userId}`)
+            .reply(200, createClipResponse);
      
-         utils.createClip(accessToken, (res) => {
-             assert.deepEqual(res, {clip: createClipResponse.data[0], userName});
-             done();
-         });
+        const res = await utils.createClip(accessToken);
+
+        assert.deepEqual(res, {clip: createClipResponse.data[0], userName});
+        done();
     });
 
-    it('returns STREAM_OFFLINE when the stream isnt live', (done) => {
+    it('returns STREAM_OFFLINE when the stream isnt live', async (done) => {
         const streamOfflineResponse = {
             status: 404,
             error: 'Not found'
-         };
+        };
 
-         const createClipNock = nock('https://api.twitch.tv')
-             .post(`/helix/clips?broadcaster_id=${userId}`)
-             .reply(200, streamOfflineResponse);
+         nock('https://api.twitch.tv')
+            .post(`/helix/clips?broadcaster_id=${userId}`)
+            .reply(200, streamOfflineResponse);
      
-         utils.createClip(accessToken, (res) => {
-             assert.deepEqual(res, {clip: 'STREAM_OFFLINE', userName});
-             done();
-         });
+        const res = await utils.createClip(accessToken);
+
+        assert.deepEqual(res, {clip: utils.STREAM_OFFLINE, userName});
+        done();
     });
 });
 

--- a/src/tests/utils.tests.js
+++ b/src/tests/utils.tests.js
@@ -36,13 +36,13 @@ describe('getUser', () => {
     });
 });
 
-describe('isStreamLiveAsync', () => {
+describe('isStreamLive', () => {
     it('returns true when it is live', async (done) => {
         nock('https://api.twitch.tv')
             .get(`/helix/streams?user_id=${userId}`)
             .reply(200, {data: [{id: 1234, user_id: 'user123'}]});
 
-        const res = await utils.isStreamLiveAsync(accessToken);
+        const res = await utils.isStreamLive(accessToken);
 
         assert.equal(res, true);
         done();
@@ -53,34 +53,10 @@ describe('isStreamLiveAsync', () => {
             .get(`/helix/streams?user_id=${userId}`)
             .reply(200, {data: []});
 
-        const res = await utils.isStreamLiveAsync(accessToken);
+        const res = await utils.isStreamLive(accessToken);
 
         assert.equal(res, false);
         done();
-    });
-});
-
-describe('isStreamLive', () => {
-    it('returns true when it is live', (done) => {
-        nock('https://api.twitch.tv')
-            .get(`/helix/streams?user_id=${userId}`)
-            .reply(200, {data: [{id: 1234, user_id: 'user123'}]});
-
-        utils.isStreamLive(accessToken, (res) => {
-            assert.equal(res, true);
-            done();
-        });
-    });
-
-    it('returns false when it is not live', (done) => {
-        nock('https://api.twitch.tv')
-            .get(`/helix/streams?user_id=${userId}`)
-            .reply(200, {data: []});
-
-        utils.isStreamLive(accessToken, (res) => {
-            assert.equal(res, false);
-            done();
-        });
     });
 });
 


### PR DESCRIPTION
**Changes:**
- Refactored utils to use async/await instead of callbacks
- Updated the subscriber endpoints to use the new endpoint (twitch deprecated the old one)


**NOTE:**
- The new Subscriber endpoint doesnt have feature parity with the old one. Mainly, it does not allow you to sort subscribers, nor does it give a subscribed date. So as of right now the best we can do is just return 5 subs and hope that one day they will update `?first=X` query param to actually be in order.
- Also this new endpoint requires additional scopes. In order for it to work properly user has to re-link their Twitch account to the Alexa skill to acquire these scopes. 